### PR TITLE
fix: 사용자 퇴장 순서 보장

### DIFF
--- a/apps/api/src/services/channel.service.ts
+++ b/apps/api/src/services/channel.service.ts
@@ -1,7 +1,6 @@
 import { injectable } from "inversify"
 
 import { ChannelRepository } from "@kwitch/database/repository"
-import { redis } from "@kwitch/database/redis"
 import { User } from "@kwitch/domain"
 
 @injectable()

--- a/apps/api/src/socket/domain/streaming.ts
+++ b/apps/api/src/socket/domain/streaming.ts
@@ -74,15 +74,15 @@ export class MediasoupStreaming implements Streaming {
   }
 
   public destroy() {
-    this.sender.sendTransport?.close()
     this.sender.producers.forEach((producer) => {
       producer.close()
     })
+    this.sender.sendTransport?.close()
     this.receivers.forEach((viewer) => {
-      viewer.recvTransport?.close()
       viewer.consumers.forEach((consumer) => {
         consumer.close()
       })
+      viewer.recvTransport?.close()
     })
     this.router.close()
   }

--- a/apps/web/app/channels/[channelId]/page.tsx
+++ b/apps/web/app/channels/[channelId]/page.tsx
@@ -120,20 +120,22 @@ export default function ChannelPage() {
   useEffect(() => {
     if (!onAir) return
 
+    let destroyed = false;
+
     socket.on("streamings:destroy", () => {
+      setOnAir(false)
+      destroyed = true
       toast({
         title: "The streamer closed the channel.",
         variant: "destructive",
       })
-      setOnAir(false)
-      return
     })
 
     return () => {
-      socket.emit("streamings:leave", channelId)
+      if (!onAir && !destroyed) socket.emit("streamings:leave", channelId)
       socket.off("streamings:destroy")
     }
-  }, [onAir])
+  }, [onAir, channelId])
 
   return (
     <>

--- a/apps/web/app/stream-manager/page.tsx
+++ b/apps/web/app/stream-manager/page.tsx
@@ -141,7 +141,7 @@ export default function StreamManager() {
                   producerOptions: {
                     kind: parameters.kind,
                     rtpParameters: parameters.rtpParameters,
-                  }
+                  },
                 },
                 (res: CustomResponse) => {
                   if (res.success === false) {
@@ -190,9 +190,7 @@ export default function StreamManager() {
     socket.emit("streamings:end", async (res: CustomResponse) => {
       if (res.success === true) {
         setOnAir(false)
-        if (videoRef.current) {
-          videoRef.current.srcObject = null
-        }
+        sendTransport.current?.close()
         toast({
           title: "Streaming ended",
           description: "The streaming has ended successfully.",


### PR DESCRIPTION
related issue: resolves #8 

```typescript
useEffect(() => {
  if (!onAir) return

  socket.on("streamings:destroy", () => {
    setOnAir(false)
    toast({
      title: "The streamer closed the channel.",
      variant: "destructive",
    })
  })

  return () => {
    socket.emit("streamings:leave", channelId)
    socket.off("streamings:destroy")
  }
}, [onAir, channelId])
```

클라이언트 측에서 `onAir` 값이 변경되면서 `streamings:leave`가 항상 emit 되기 때문에 발생한 오류였습니다.

`destroyed: boolean`를 이용해 해당 채널이 꺼졌는 지 확인하고 emit하는 과정이 추가되었습니다.