### PR TITLE
hotfix: missingSuspenseWithCSRBailout

### DIFF
--- a/apps/web/app/oauth2/callback/page.tsx
+++ b/apps/web/app/oauth2/callback/page.tsx
@@ -1,14 +1,15 @@
 "use client"
 
+import Loading from "@/components/loading"
 import { LOCAL_STORAGE_KEYS } from "@/const/localStorage"
 import { useAuth } from "@/provider/auth-provider"
 import { useToast } from "@kwitch/ui/hooks/use-toast"
 import { useParams, useRouter, useSearchParams } from "next/navigation"
-import { useEffect } from "react"
+import { Suspense, useEffect } from "react"
 
 export default function OAuth2CallbackPage() {
   const router = useRouter()
-  const searchParams = useSearchParams() || new URLSearchParams()
+  const searchParams = useSearchParams() ?? new URLSearchParams()
   const { toast } = useToast()
 
   const accessToken = searchParams.get("accessToken") || ""
@@ -25,7 +26,9 @@ export default function OAuth2CallbackPage() {
 
     localStorage.setItem(LOCAL_STORAGE_KEYS.ACCESS_TOKEN, accessToken)
     router.replace("/")
-  })
+  }, [])
 
-  return null
+  return (
+      <Loading />
+  )
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,6 +2,9 @@
 
 const nextConfig = {
   reactStrictMode: false,
+  experimental: {
+    missingSuspenseWithCSRBailout: false,
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Reading search parameters through useSearchParams() without a Suspense boundary will opt the entire page into client-side rendering. This could cause your page to be blank until the client-side JavaScript has loaded.

```
module.exports = {
  experimental: {
    missingSuspenseWithCSRBailout: false,
  },
}
```