### PR TITLE
fix: prevent send when composing

### DIFF
--- a/apps/web/components/channels/chat.tsx
+++ b/apps/web/components/channels/chat.tsx
@@ -35,14 +35,11 @@ export const ChatComponent = ({
   }
 
   const handleOnKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault()
-      submitMessage()
-    }
+    if (e.nativeEvent.isComposing) return
 
-    if (e.key === "Enter" && e.shiftKey) {
+    if (e.key === "Enter") {
       e.preventDefault()
-      setCurrentMessage((prev) => prev + "\n")
+      e.shiftKey ? setCurrentMessage((prev) => prev + "\n") : submitMessage()
     }
   }
 


### PR DESCRIPTION
```jsx
const handleOnKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
  if (e.nativeEvent.isComposing) return

  if (e.key === "Enter") {
    e.preventDefault()
    e.shiftKey ? setCurrentMessage((prev) => prev + "\n") : submitMessage()
  }
}
```